### PR TITLE
feat: add data folder for dataloader functions

### DIFF
--- a/data/dataloader.py
+++ b/data/dataloader.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+class DGADatasetLoader:
+    def __init__(self, dga_path='data/dga_domains.csv', benign_path='data/benign_domains.csv'):
+        self.dga_path = dga_path
+        self.benign_path = benign_path
+    
+    def load_datasets(self, test_size=0.2, random_state=42):
+        # Load DGA domains
+        dga_df = pd.read_csv(self.dga_path)
+        dga_df['label'] = 1  # DGA domains labeled as 1
+        
+        # Load benign domains
+        benign_df = pd.read_csv(self.benign_path)
+        benign_df['label'] = 0  # Benign domains labeled as 0
+        
+        # Combine datasets
+        combined_df = pd.concat([dga_df, benign_df], ignore_index=True)
+        
+        # Split into train and test sets
+        X_train, X_test, y_train, y_test = train_test_split(
+            combined_df['domain'], 
+            combined_df['label'], 
+            test_size=test_size, 
+            random_state=random_state
+        )
+        
+        return X_train, X_test, y_train, y_test


### PR DESCRIPTION
This pull request introduces a new data loader class for DGA (Domain Generation Algorithms) datasets in the `data/dataloader.py` file. The class is designed to load and preprocess DGA and benign domain datasets, and split them into training and testing sets.

Key changes include:

* **New Class Addition:**
  * [`DGADatasetLoader`](diffhunk://#diff-f41d5d93e76efa5638a691f8947c424c58ec3f51b884fc0d235ddd324dd574f2R1-R30): A new class to load and preprocess DGA and benign domain datasets. It includes methods to read CSV files, label the data, combine datasets, and split them into training and testing sets.

* **Library Imports:**
  * Added imports for `pandas`, `numpy`, and `train_test_split` from `sklearn.model_selection` to handle data loading and splitting tasks.